### PR TITLE
Avoid Discord auto-spoiler links

### DIFF
--- a/commands/post_fansub.py
+++ b/commands/post_fansub.py
@@ -19,7 +19,7 @@ async def post_fansub(client, message, args):
         if not link.startswith("http"):
             await private_msg(message, "Can't find http link.")
             return
-        description += f" [{lname}]({link}) ||"
+        description += f" [{lname}]({link}) ‖"
 
     embed = discord.Embed(title=title, description=description[:-3], color=0x000000)
     embed.set_author(name=message.author.name, icon_url=message.author.avatar_url)


### PR DESCRIPTION
Changes the divider between link names to stop Discord from making the link a spoiler. Double " | " changed to Unicode U+2016 " ‖ " . Currently looks like [this](https://u.cubeupload.com/davste0816/Untitled3.png).